### PR TITLE
Use methods instead of having a single "insert" function (and rename module)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -33,6 +33,28 @@ export function insert(textarea: HTMLTextAreaElement | HTMLInputElement, text: s
 	}
 }
 
+export function set(field: HTMLTextAreaElement | HTMLInputElement, text: string): void {
+	field.select();
+	insert(field, text);
+}
+
+export function getSelection(field: HTMLTextAreaElement | HTMLInputElement): string {
+	return field.value.slice(field.selectionStart!, field.selectionEnd!);
+}
+
+export function wrapSelection(field: HTMLTextAreaElement | HTMLInputElement, wrap: string, wrapEnd?: string): void {
+	const {selectionStart, selectionEnd} = field;
+	const selection = getSelection(field);
+	insert(field, wrap + selection + (wrapEnd ?? wrap));
+
+	// Restore the selection around the previously-selected text
+	field.selectionStart = selectionStart! + wrap.length;
+	field.selectionEnd = selectionEnd! + wrap.length;
+}
+
 export default {
-	insert
+	insert,
+	set,
+	wrapSelection,
+	getSelection
 };

--- a/index.ts
+++ b/index.ts
@@ -50,10 +50,3 @@ export function wrapSelection(field: HTMLTextAreaElement | HTMLInputElement, wra
 	field.selectionStart = selectionStart! + wrap.length;
 	field.selectionEnd = selectionEnd! + wrap.length;
 }
-
-export default {
-	insert,
-	set,
-	wrapSelection,
-	getSelection
-};

--- a/index.ts
+++ b/index.ts
@@ -1,34 +1,33 @@
-function insertTextFirefox(textarea: HTMLTextAreaElement | HTMLInputElement, text: string): void {
+function insertTextFirefox(field: HTMLTextAreaElement | HTMLInputElement, text: string): void {
 	// Found on https://www.everythingfrontend.com/posts/insert-text-into-textarea-at-cursor-position.html 🎈
-	textarea.setRangeText(
+	field.setRangeText(
 		text,
-		textarea.selectionStart || 0,
-		textarea.selectionEnd || 0,
+		field.selectionStart || 0,
+		field.selectionEnd || 0,
 		'end' // Without this, the cursor is either at the beginning or `text` remains selected
 	);
 
-	textarea.dispatchEvent(new InputEvent('input', {
+	field.dispatchEvent(new InputEvent('input', {
 		data: text,
 		inputType: 'insertText',
 		isComposing: false // TODO: fix @types/jsdom, this shouldn't be required
 	}));
 }
 
-/** Replace selection with text, with Firefox support */
-export function insert(textarea: HTMLTextAreaElement | HTMLInputElement, text: string): void {
-	const document = textarea.ownerDocument!;
+export function insert(field: HTMLTextAreaElement | HTMLInputElement, text: string): void {
+	const document = field.ownerDocument!;
 	const initialFocus = document.activeElement;
-	if (initialFocus !== textarea) {
-		textarea.focus();
+	if (initialFocus !== field) {
+		field.focus();
 	}
 
 	if (!document.execCommand('insertText', false, text)) {
-		insertTextFirefox(textarea, text);
+		insertTextFirefox(field, text);
 	}
 
 	if (initialFocus === document.body) {
-		textarea.blur();
-	} else if (initialFocus instanceof HTMLElement && initialFocus !== textarea) {
+		field.blur();
+	} else if (initialFocus instanceof HTMLElement && initialFocus !== field) {
 		initialFocus.focus();
 	}
 }

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ function insertTextFirefox(field: HTMLTextAreaElement | HTMLInputElement, text: 
 	}));
 }
 
+/** Inserts `text` at the cursor’s position, replacing any selection, with **undo** support and by firing the `input` event. */
 export function insert(field: HTMLTextAreaElement | HTMLInputElement, text: string): void {
 	const document = field.ownerDocument!;
 	const initialFocus = document.activeElement;
@@ -32,15 +33,18 @@ export function insert(field: HTMLTextAreaElement | HTMLInputElement, text: stri
 	}
 }
 
+/** Replaces the entire content, equivalent to `field.value = text` but with **undo** support and by firing the `input` event. */
 export function set(field: HTMLTextAreaElement | HTMLInputElement, text: string): void {
 	field.select();
 	insert(field, text);
 }
 
+/** Get the selected text in a field or an empty string if nothing is selected. */
 export function getSelection(field: HTMLTextAreaElement | HTMLInputElement): string {
 	return field.value.slice(field.selectionStart!, field.selectionEnd!);
 }
 
+/** Adds the `wrappingText` before and after field’s selection (or cursor). If `endWrappingText` is provided, it will be used instead of `wrappingText` at on the right. */
 export function wrapSelection(field: HTMLTextAreaElement | HTMLInputElement, wrap: string, wrapEnd?: string): void {
 	const {selectionStart, selectionEnd} = field;
 	const selection = getSelection(field);

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ function insertTextFirefox(textarea: HTMLTextAreaElement | HTMLInputElement, tex
 }
 
 /** Replace selection with text, with Firefox support */
-export default function insertText(textarea: HTMLTextAreaElement | HTMLInputElement, text: string): void {
+export function insert(textarea: HTMLTextAreaElement | HTMLInputElement, text: string): void {
 	const document = textarea.ownerDocument!;
 	const initialFocus = document.activeElement;
 	if (initialFocus !== textarea) {
@@ -26,10 +26,13 @@ export default function insertText(textarea: HTMLTextAreaElement | HTMLInputElem
 		insertTextFirefox(textarea, text);
 	}
 
-	// TODO: Replace block with `blur-accessibly`
 	if (initialFocus === document.body) {
 		textarea.blur();
 	} else if (initialFocus instanceof HTMLElement && initialFocus !== textarea) {
 		initialFocus.focus();
 	}
 }
+
+export default {
+	insert
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "text-field-edit",
-	"version": "2.0.1",
+	"version": "3.0.0-0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "insert-text-textarea",
+	"name": "text-field-edit",
 	"version": "2.0.1",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "text-field-edit",
 	"version": "3.0.0-0",
-	"description": "Insert text in a textarea and input[text] (supports Firefox and Undo, where possible)",
+	"description": "Insert text in a <textarea> and <input> (supports Firefox and Undo, where possible)",
 	"keywords": [
 		"at cursor",
 		"cross-browser",
@@ -12,6 +12,7 @@
 		"field",
 		"form",
 		"inject",
+		"event",
 		"inserttext",
 		"manipulation",
 		"text area"
@@ -26,7 +27,7 @@
 	"module": "index.js",
 	"scripts": {
 		"build": "tsc",
-		"prepare": "tsc --sourceMap false",
+		"prepublishOnly": "tsc --sourceMap false",
 		"test": "npm-run-all --silent build --parallel test:*",
 		"test:blink": "browserify -p esmify test.js | tape-run --browser chrome",
 		"test:gecko": "browserify -p esmify test.js | tape-run --browser firefox",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "insert-text-textarea",
-	"version": "2.0.1",
+	"name": "text-field-edit",
+	"version": "0.0.0",
 	"description": "Insert text in a textarea and input[text] (supports Firefox and Undo, where possible)",
 	"keywords": [
 		"at cursor",
@@ -16,7 +16,7 @@
 		"manipulation",
 		"text area"
 	],
-	"repository": "fregante/insert-text-textarea",
+	"repository": "fregante/text-field-edit",
 	"license": "MIT",
 	"files": [
 		"index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "text-field-edit",
-	"version": "0.0.0",
+	"version": "3.0.0-0",
 	"description": "Insert text in a textarea and input[text] (supports Firefox and Undo, where possible)",
 	"keywords": [
 		"at cursor",

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ import * as textFieldEdit from 'text-field-edit';
 
 ## Usage
 
-Insert text at the cursor, replacing any possible selected text:
+Insert text at the cursor, replacing any possible selected text, acting like a `paste` would:
 
 ```js
 const input = document.querySelector('input');
@@ -69,7 +69,7 @@ textFieldEdit.insert(field, '🥳');
 
 #### field
 
-Type: `HTMLTextAreaElement` `HTMLInputElement`
+Type: `HTMLTextAreaElement | HTMLInputElement`
 
 #### text
 
@@ -88,7 +88,7 @@ textFieldEdit.set(textarea, 'New text!');
 
 #### field
 
-Type: `HTMLTextAreaElement` `HTMLInputElement`
+Type: `HTMLTextAreaElement | HTMLInputElement`
 
 #### text
 
@@ -96,9 +96,9 @@ Type: `string`
 
 The new value that the field will have.
 
-### textFieldEdit.wrapSelection(field, wrappingText[, endWrappingText])
+### textFieldEdit.wrapSelection(field, wrappingText, endWrappingText?)
 
-Adds the `wrappingText` before and after field's selection (or cursor). If `endWrappingText` is provided, it will be used instead of `wrappingText` at on the right.
+Adds the `wrappingText` before and after field’s selection (or cursor). If `endWrappingText` is provided, it will be used instead of `wrappingText` at on the right.
 
 ```js
 const field = document.querySelector('textarea');
@@ -114,7 +114,7 @@ textFieldEdit.wrapSelection(field, '(', ')');
 
 ### textFieldEdit.getSelection(field)
 
-Utility method to get the selected text in a field.
+Utility method to get the selected text in a field or an empty string if nothing is selected.
 
 ```js
 const field = document.querySelector('textarea');
@@ -126,7 +126,7 @@ textFieldEdit.getSelection(field);
 
 #### field
 
-Type: `HTMLTextAreaElement` `HTMLInputElement`
+Type: `HTMLTextAreaElement | HTMLInputElement`
 
 # Related
 

--- a/readme.md
+++ b/readme.md
@@ -47,22 +47,88 @@ button.addEventListener(event => {
 });
 ```
 
-This will wrap the selected text (if any) with `**` on both sides:
+This will act like `field.value = 'New value'` but with **undo** support and by firing the `input` event:
 
 ```js
 const textarea = document.querySelector('textarea');
-const button = document.querySelector('.js-markdown-make-text-bold');
-button.addEventListener(event => {
-	textFieldEdit.wrap(textarea, '**');
+const resetButton = document.querySelector('.js-markdown-reset-field');
+resetButton.addEventListener(event => {
+	textFieldEdit.set(textarea, 'New value');
 });
 ```
 
-This will replace the entire content, equivalent to `field.value = 'New text!'` but with **undo** support:
+## API
+
+### textFieldEdit.insert(field, text)
+
+Inserts `text` at the cursor’s position, replacing any selection.
+
+```js
+const field = document.querySelector('input[type="text"]');
+textFieldEdit.insert(field, '🥳');
+// Changes field's value from 'Party|' to 'Party🥳|' (where | is the cursor)
+```
+
+#### field
+
+Type: `HTMLTextAreaElement` `HTMLInputElement`
+
+#### text
+
+Type: `string`
+
+The text to insert at the cursor's position.
+
+### textFieldEdit.set(field, text)
+
+Replaces the entire content, equivalent to `field.value = 'New text!'` but with **undo** support and by firing the `input` event:
 
 ```js
 const textarea = document.querySelector('textarea');
 textFieldEdit.set(textarea, 'New text!');
 ```
+
+#### field
+
+Type: `HTMLTextAreaElement` `HTMLInputElement`
+
+#### text
+
+Type: `string`
+
+The new value that the field will have.
+
+### textFieldEdit.wrapSelection(field, wrappingText[, endWrappingText])
+
+Adds the `wrappingText` before and after field's selection (or cursor). If `endWrappingText` is provided, it will be used instead of `wrappingText` at on the right.
+
+```js
+const field = document.querySelector('textarea');
+textFieldEdit.wrapSelection(field, '**');
+// Changes the field's value from 'I |love| gudeg' to 'I **|love|** gudeg' (where | marks the selected text)
+```
+
+```js
+const field = document.querySelector('textarea');
+textFieldEdit.wrapSelection(field, '(', ')');
+// Changes the field's value from '|almost| cool' to '(|almost|) cool' (where | marks the selected text)
+```
+
+### textFieldEdit.getSelection(field)
+
+Utility method to get the selected text in a field.
+
+```js
+const field = document.querySelector('textarea');
+textFieldEdit.getSelection(field);
+// => 'almost'
+// If the field's value is '|almost| cool' (where | marks the selected text)
+
+```
+
+#### field
+
+Type: `HTMLTextAreaElement` `HTMLInputElement`
 
 # Related
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
-# insert-text-textarea [![][badge-gzip]](#link-npm)
+# text-field-edit [![][badge-gzip]](#link-npm)
 
-  [badge-gzip]: https://img.shields.io/bundlephobia/minzip/insert-text-textarea.svg?label=gzipped
-  [link-npm]: https://www.npmjs.com/package/insert-text-textarea
+  [badge-gzip]: https://img.shields.io/bundlephobia/minzip/text-field-edit.svg?label=gzipped
+  [link-npm]: https://www.npmjs.com/package/text-field-edit
 
 <img align="right" width="360" src="https://user-images.githubusercontent.com/1402241/55075820-e3645800-50ce-11e9-8591-9195c3cdfc8a.gif">
 
@@ -22,17 +22,17 @@ If you need IE support, use [insert-text-at-cursor](https://github.com/grassator
 
 ## Install
 
-You can just download the [standalone bundle](https://packd.fregante.now.sh/insert-text-textarea@latest?name=insertText)
+You can just download the [standalone bundle](https://packd.fregante.now.sh/text-field-edit@latest?name=insertText)
 
 Or use `npm`:
 
 ```sh
-npm install insert-text-textarea
+npm install text-field-edit
 ```
 
 ```js
 // This module is only offered as a ES Module
-import insertText from 'insert-text-textarea';
+import insertText from 'text-field-edit';
 ```
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ npm install text-field-edit
 
 ```js
 // This module is only offered as a ES Module
-import textFieldEdit from 'text-field-edit';
+import * as textFieldEdit from 'text-field-edit';
 ```
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ If you need IE support, use [insert-text-at-cursor](https://github.com/grassator
 
 ## Install
 
-You can just download the [standalone bundle](https://packd.fregante.now.sh/text-field-edit@latest?name=insertText)
+You can just download the [standalone bundle](https://packd.fregante.now.sh/text-field-edit)
 
 Or use `npm`:
 
@@ -32,7 +32,7 @@ npm install text-field-edit
 
 ```js
 // This module is only offered as a ES Module
-import insertText from 'text-field-edit';
+import textFieldEdit from 'text-field-edit';
 ```
 
 ## Usage
@@ -43,7 +43,7 @@ Insert text at the cursor, replacing any possible selected text:
 const textarea = document.querySelector('textarea');
 const button = document.querySelector('.js-add-signature');
 button.addEventListener(event => {
-	insertText(textarea, 'Made by 🐝 with pollen.');
+	textFieldEdit.insert(textarea, 'Made by 🐝 with pollen.');
 });
 ```
 
@@ -53,12 +53,7 @@ This will wrap the selected text (if any) with `**` on both sides:
 const textarea = document.querySelector('textarea');
 const button = document.querySelector('.js-markdown-make-text-bold');
 button.addEventListener(event => {
-	// Don't use `getSelection()` if you want Firefox support
-	const selectedText = value.slice(
-		textarea.selectionStart,
-		textarea.selectionEnd
-	);
-	insertText(textarea, '**' + selectedText + '**');
+	textFieldEdit.wrap(textarea, '**');
 });
 ```
 
@@ -66,8 +61,7 @@ This will replace the entire content, equivalent to `field.value = 'New text!'` 
 
 ```js
 const textarea = document.querySelector('textarea');
-textarea.select(); // The text needs to be selected so it will be replaced
-insertText(textarea, 'New text!');
+textFieldEdit.set(textarea, 'New text!');
 ```
 
 # Related

--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,7 @@
 
 <img align="right" width="360" src="https://user-images.githubusercontent.com/1402241/55075820-e3645800-50ce-11e9-8591-9195c3cdfc8a.gif">
 
-> Insert text in a `textarea` and `input[type=text]` (supports Firefox and Undo, where possible)
-
-The text will be inserted **after the cursor** or it will replace any text that's selected, acting like a `paste` would.
+> Insert text in a `<textarea>` and `<input>` (supports Firefox and Undo, where possible)
 
 You should use this instead of setting the `field.value` directly because:
 
@@ -40,10 +38,10 @@ import textFieldEdit from 'text-field-edit';
 Insert text at the cursor, replacing any possible selected text:
 
 ```js
-const textarea = document.querySelector('textarea');
+const input = document.querySelector('input');
 const button = document.querySelector('.js-add-signature');
 button.addEventListener(event => {
-	textFieldEdit.insert(textarea, 'Made by 🐝 with pollen.');
+	textFieldEdit.insert(input, 'Made by 🐝 with pollen.');
 });
 ```
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'tape';
-import {insert, set, getSelection, wrapSelection} from '.';
+import * as textFieldEdit from '.';
 
 const getField = (value = '', start = undefined, end = undefined, type = 'textarea') => {
 	const field = document.createElement(type);
@@ -16,7 +16,7 @@ const getField = (value = '', start = undefined, end = undefined, type = 'textar
 test('insert() preserves focused item, if focusable', t => {
 	t.equal(document.activeElement, document.body);
 	const field = getField();
-	insert(field, 'A');
+	textFieldEdit.insert(field, 'A');
 	t.equal(document.activeElement, document.body);
 	t.end();
 });
@@ -24,7 +24,7 @@ test('insert() preserves focused item, if focusable', t => {
 test('insert() inserts text in empty field', t => {
 	const field = getField();
 	t.equal(field.value, '');
-	insert(field, 'a');
+	textFieldEdit.insert(field, 'a');
 	t.equal(field.value, 'a');
 	t.equal(field.selectionStart, 1);
 	t.equal(field.selectionEnd, 1);
@@ -34,7 +34,7 @@ test('insert() inserts text in empty field', t => {
 test('insert() inserts text in empty input element', t => {
 	const field = getField('', undefined, undefined, 'input');
 	t.equal(field.value, '');
-	insert(field, 'a');
+	textFieldEdit.insert(field, 'a');
 	t.equal(field.value, 'a');
 	t.equal(field.selectionStart, 1);
 	t.equal(field.selectionEnd, 1);
@@ -44,7 +44,7 @@ test('insert() inserts text in empty input element', t => {
 test('insert() appends text to unselected field', t => {
 	const field = getField('W');
 	t.equal(field.value, 'W');
-	insert(field, 'O');
+	textFieldEdit.insert(field, 'O');
 	t.equal(field.value, 'WO');
 	t.equal(field.selectionStart, 2);
 	t.equal(field.selectionEnd, 2);
@@ -54,7 +54,7 @@ test('insert() appends text to unselected field', t => {
 test('insert() inserts text in the middle', t => {
 	const field = getField('WO', 1, 1);
 	t.equal(field.value, 'WO');
-	insert(field, 'A');
+	textFieldEdit.insert(field, 'A');
 	t.equal(field.value, 'WAO');
 	t.equal(field.selectionStart, 2);
 	t.equal(field.selectionEnd, 2);
@@ -64,7 +64,7 @@ test('insert() inserts text in the middle', t => {
 test('insert() replaces selected text', t => {
 	const field = getField('WO', 0, 1);
 	t.equal(field.value, 'WO');
-	insert(field, 'A');
+	textFieldEdit.insert(field, 'A');
 	t.equal(field.value, 'AO');
 	t.equal(field.selectionStart, 1);
 	t.equal(field.selectionEnd, 1);
@@ -78,13 +78,13 @@ test('insert() fires input event', t => {
 		// TODO: t.equal(event.inputType, 'insert');
 		t.end();
 	});
-	insert(field, 'A');
+	textFieldEdit.insert(field, 'A');
 });
 
 test('set() replaces the whole content', t => {
 	const field = getField('WO', 0, 1);
 	t.equal(field.value, 'WO');
-	set(field, 'ABC');
+	textFieldEdit.set(field, 'ABC');
 	t.equal(field.value, 'ABC');
 	t.equal(field.selectionStart, 3);
 	t.equal(field.selectionEnd, 3);
@@ -94,19 +94,19 @@ test('set() replaces the whole content', t => {
 test('getSelection()', t => {
 	const field = getField('WOA', 1, 2);
 	t.equal(field.value, 'WOA');
-	t.equal(getSelection(field), 'O');
+	t.equal(textFieldEdit.getSelection(field), 'O');
 	t.end();
 });
 
 test('getSelection() without selection', t => {
 	const field = getField('WOA', 3, 3);
-	t.equal(getSelection(field), '');
+	t.equal(textFieldEdit.getSelection(field), '');
 	t.end();
 });
 
 test('wrapSelection() wraps selected text', t => {
 	const field = getField('WOA', 1, 2);
-	wrapSelection(field, '*');
+	textFieldEdit.wrapSelection(field, '*');
 	t.equal(field.value, 'W*O*A');
 	t.equal(field.selectionStart, 2);
 	t.equal(field.selectionEnd, 3);
@@ -115,7 +115,7 @@ test('wrapSelection() wraps selected text', t => {
 
 test('wrapSelection() wraps selected text with different characters', t => {
 	const field = getField('WOA', 1, 2);
-	wrapSelection(field, '[', ']');
+	textFieldEdit.wrapSelection(field, '[', ']');
 	t.equal(field.value, 'W[O]A');
 	t.equal(field.selectionStart, 2);
 	t.equal(field.selectionEnd, 3);
@@ -124,7 +124,7 @@ test('wrapSelection() wraps selected text with different characters', t => {
 
 test('wrapSelection() adds wrapping characters even without selection', t => {
 	const field = getField('OA', 1, 1);
-	wrapSelection(field, '[', ']');
+	textFieldEdit.wrapSelection(field, '[', ']');
 	t.equal(field.value, 'O[]A');
 	t.equal(field.selectionStart, 2);
 	t.equal(field.selectionEnd, 2);

--- a/test.js
+++ b/test.js
@@ -15,118 +15,118 @@ const getField = (value = '', start = undefined, end = undefined, type = 'textar
 
 test('insert() preserves focused item, if focusable', t => {
 	t.equal(document.activeElement, document.body);
-	const textarea = getField();
-	insert(textarea, 'A');
+	const field = getField();
+	insert(field, 'A');
 	t.equal(document.activeElement, document.body);
 	t.end();
 });
 
-test('insert() inserts text in empty textarea', t => {
-	const textarea = getField();
-	t.equal(textarea.value, '');
-	insert(textarea, 'a');
-	t.equal(textarea.value, 'a');
-	t.equal(textarea.selectionStart, 1);
-	t.equal(textarea.selectionEnd, 1);
+test('insert() inserts text in empty field', t => {
+	const field = getField();
+	t.equal(field.value, '');
+	insert(field, 'a');
+	t.equal(field.value, 'a');
+	t.equal(field.selectionStart, 1);
+	t.equal(field.selectionEnd, 1);
 	t.end();
 });
 
-test('insert() inserts text in empty input[type=text]', t => {
-	const textarea = getField('', undefined, undefined, 'input');
-	t.equal(textarea.value, '');
-	insert(textarea, 'a');
-	t.equal(textarea.value, 'a');
-	t.equal(textarea.selectionStart, 1);
-	t.equal(textarea.selectionEnd, 1);
+test('insert() inserts text in empty input element', t => {
+	const field = getField('', undefined, undefined, 'input');
+	t.equal(field.value, '');
+	insert(field, 'a');
+	t.equal(field.value, 'a');
+	t.equal(field.selectionStart, 1);
+	t.equal(field.selectionEnd, 1);
 	t.end();
 });
 
 test('insert() appends text to unselected field', t => {
-	const textarea = getField('W');
-	t.equal(textarea.value, 'W');
-	insert(textarea, 'O');
-	t.equal(textarea.value, 'WO');
-	t.equal(textarea.selectionStart, 2);
-	t.equal(textarea.selectionEnd, 2);
+	const field = getField('W');
+	t.equal(field.value, 'W');
+	insert(field, 'O');
+	t.equal(field.value, 'WO');
+	t.equal(field.selectionStart, 2);
+	t.equal(field.selectionEnd, 2);
 	t.end();
 });
 
 test('insert() inserts text in the middle', t => {
-	const textarea = getField('WO', 1, 1);
-	t.equal(textarea.value, 'WO');
-	insert(textarea, 'A');
-	t.equal(textarea.value, 'WAO');
-	t.equal(textarea.selectionStart, 2);
-	t.equal(textarea.selectionEnd, 2);
+	const field = getField('WO', 1, 1);
+	t.equal(field.value, 'WO');
+	insert(field, 'A');
+	t.equal(field.value, 'WAO');
+	t.equal(field.selectionStart, 2);
+	t.equal(field.selectionEnd, 2);
 	t.end();
 });
 
 test('insert() replaces selected text', t => {
-	const textarea = getField('WO', 0, 1);
-	t.equal(textarea.value, 'WO');
-	insert(textarea, 'A');
-	t.equal(textarea.value, 'AO');
-	t.equal(textarea.selectionStart, 1);
-	t.equal(textarea.selectionEnd, 1);
+	const field = getField('WO', 0, 1);
+	t.equal(field.value, 'WO');
+	insert(field, 'A');
+	t.equal(field.value, 'AO');
+	t.equal(field.selectionStart, 1);
+	t.equal(field.selectionEnd, 1);
 	t.end();
 });
 
 test('insert() fires input event', t => {
-	const textarea = getField();
-	textarea.addEventListener('input', event => {
+	const field = getField();
+	field.addEventListener('input', event => {
 		t.equal(event.type, 'input');
 		// TODO: t.equal(event.inputType, 'insert');
 		t.end();
 	});
-	insert(textarea, 'A');
+	insert(field, 'A');
 });
 
 test('set() replaces the whole content', t => {
-	const textarea = getField('WO', 0, 1);
-	t.equal(textarea.value, 'WO');
-	set(textarea, 'ABC');
-	t.equal(textarea.value, 'ABC');
-	t.equal(textarea.selectionStart, 3);
-	t.equal(textarea.selectionEnd, 3);
+	const field = getField('WO', 0, 1);
+	t.equal(field.value, 'WO');
+	set(field, 'ABC');
+	t.equal(field.value, 'ABC');
+	t.equal(field.selectionStart, 3);
+	t.equal(field.selectionEnd, 3);
 	t.end();
 });
 
 test('getSelection()', t => {
-	const textarea = getField('WOA', 1, 2);
-	t.equal(textarea.value, 'WOA');
-	t.equal(getSelection(textarea), 'O');
+	const field = getField('WOA', 1, 2);
+	t.equal(field.value, 'WOA');
+	t.equal(getSelection(field), 'O');
 	t.end();
 });
 
 test('getSelection() without selection', t => {
-	const textarea = getField('WOA', 3, 3);
-	t.equal(getSelection(textarea), '');
+	const field = getField('WOA', 3, 3);
+	t.equal(getSelection(field), '');
 	t.end();
 });
 
 test('wrapSelection() wraps selected text', t => {
-	const textarea = getField('WOA', 1, 2);
-	wrapSelection(textarea, '*');
-	t.equal(textarea.value, 'W*O*A');
-	t.equal(textarea.selectionStart, 2);
-	t.equal(textarea.selectionEnd, 3);
+	const field = getField('WOA', 1, 2);
+	wrapSelection(field, '*');
+	t.equal(field.value, 'W*O*A');
+	t.equal(field.selectionStart, 2);
+	t.equal(field.selectionEnd, 3);
 	t.end();
 });
 
 test('wrapSelection() wraps selected text with different characters', t => {
-	const textarea = getField('WOA', 1, 2);
-	wrapSelection(textarea, '[', ']');
-	t.equal(textarea.value, 'W[O]A');
-	t.equal(textarea.selectionStart, 2);
-	t.equal(textarea.selectionEnd, 3);
+	const field = getField('WOA', 1, 2);
+	wrapSelection(field, '[', ']');
+	t.equal(field.value, 'W[O]A');
+	t.equal(field.selectionStart, 2);
+	t.equal(field.selectionEnd, 3);
 	t.end();
 });
 
 test('wrapSelection() adds wrapping characters even without selection', t => {
-	const textarea = getField('OA', 1, 1);
-	wrapSelection(textarea, '[', ']');
-	t.equal(textarea.value, 'O[]A');
-	t.equal(textarea.selectionStart, 2);
-	t.equal(textarea.selectionEnd, 2);
+	const field = getField('OA', 1, 1);
+	wrapSelection(field, '[', ']');
+	t.equal(field.value, 'O[]A');
+	t.equal(field.selectionStart, 2);
+	t.equal(field.selectionEnd, 2);
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'tape';
-import insertText from '.';
+import {insert} from '.';
 
 const getField = (value = '', start = undefined, end = undefined, type = 'textarea') => {
 	const field = document.createElement(type);
@@ -16,7 +16,7 @@ const getField = (value = '', start = undefined, end = undefined, type = 'textar
 test('preserve focused item, if focusable', t => {
 	t.equal(document.activeElement, document.body);
 	const textarea = getField();
-	insertText(textarea, 'A');
+	insert(textarea, 'A');
 	t.equal(document.activeElement, document.body);
 	t.end();
 });
@@ -24,7 +24,7 @@ test('preserve focused item, if focusable', t => {
 test('insert text in empty textarea', t => {
 	const textarea = getField();
 	t.equal(textarea.value, '');
-	insertText(textarea, 'a');
+	insert(textarea, 'a');
 	t.equal(textarea.value, 'a');
 	t.equal(textarea.selectionStart, 1);
 	t.equal(textarea.selectionEnd, 1);
@@ -34,7 +34,7 @@ test('insert text in empty textarea', t => {
 test('insert text in empty input[type=text]', t => {
 	const textarea = getField('', undefined, undefined, 'input');
 	t.equal(textarea.value, '');
-	insertText(textarea, 'a');
+	insert(textarea, 'a');
 	t.equal(textarea.value, 'a');
 	t.equal(textarea.selectionStart, 1);
 	t.equal(textarea.selectionEnd, 1);
@@ -44,7 +44,7 @@ test('insert text in empty input[type=text]', t => {
 test('append text to unselected field', t => {
 	const textarea = getField('W');
 	t.equal(textarea.value, 'W');
-	insertText(textarea, 'O');
+	insert(textarea, 'O');
 	t.equal(textarea.value, 'WO');
 	t.equal(textarea.selectionStart, 2);
 	t.equal(textarea.selectionEnd, 2);
@@ -54,7 +54,7 @@ test('append text to unselected field', t => {
 test('insert text in the middle', t => {
 	const textarea = getField('WO', 1, 1);
 	t.equal(textarea.value, 'WO');
-	insertText(textarea, 'A');
+	insert(textarea, 'A');
 	t.equal(textarea.value, 'WAO');
 	t.equal(textarea.selectionStart, 2);
 	t.equal(textarea.selectionEnd, 2);
@@ -64,7 +64,7 @@ test('insert text in the middle', t => {
 test('replace selected text', t => {
 	const textarea = getField('WO', 0, 1);
 	t.equal(textarea.value, 'WO');
-	insertText(textarea, 'A');
+	insert(textarea, 'A');
 	t.equal(textarea.value, 'AO');
 	t.equal(textarea.selectionStart, 1);
 	t.equal(textarea.selectionEnd, 1);
@@ -75,8 +75,8 @@ test('fire input event', t => {
 	const textarea = getField();
 	textarea.addEventListener('input', event => {
 		t.equal(event.type, 'input');
-		// TODO: t.equal(event.inputType, 'insertText');
+		// TODO: t.equal(event.inputType, 'insert');
 		t.end();
 	});
-	insertText(textarea, 'A');
+	insert(textarea, 'A');
 });

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'tape';
-import {insert} from '.';
+import {insert, set, getSelection, wrapSelection} from '.';
 
 const getField = (value = '', start = undefined, end = undefined, type = 'textarea') => {
 	const field = document.createElement(type);
@@ -13,7 +13,7 @@ const getField = (value = '', start = undefined, end = undefined, type = 'textar
 	return field;
 };
 
-test('preserve focused item, if focusable', t => {
+test('insert() preserves focused item, if focusable', t => {
 	t.equal(document.activeElement, document.body);
 	const textarea = getField();
 	insert(textarea, 'A');
@@ -21,7 +21,7 @@ test('preserve focused item, if focusable', t => {
 	t.end();
 });
 
-test('insert text in empty textarea', t => {
+test('insert() inserts text in empty textarea', t => {
 	const textarea = getField();
 	t.equal(textarea.value, '');
 	insert(textarea, 'a');
@@ -31,7 +31,7 @@ test('insert text in empty textarea', t => {
 	t.end();
 });
 
-test('insert text in empty input[type=text]', t => {
+test('insert() inserts text in empty input[type=text]', t => {
 	const textarea = getField('', undefined, undefined, 'input');
 	t.equal(textarea.value, '');
 	insert(textarea, 'a');
@@ -41,7 +41,7 @@ test('insert text in empty input[type=text]', t => {
 	t.end();
 });
 
-test('append text to unselected field', t => {
+test('insert() appends text to unselected field', t => {
 	const textarea = getField('W');
 	t.equal(textarea.value, 'W');
 	insert(textarea, 'O');
@@ -51,7 +51,7 @@ test('append text to unselected field', t => {
 	t.end();
 });
 
-test('insert text in the middle', t => {
+test('insert() inserts text in the middle', t => {
 	const textarea = getField('WO', 1, 1);
 	t.equal(textarea.value, 'WO');
 	insert(textarea, 'A');
@@ -61,7 +61,7 @@ test('insert text in the middle', t => {
 	t.end();
 });
 
-test('replace selected text', t => {
+test('insert() replaces selected text', t => {
 	const textarea = getField('WO', 0, 1);
 	t.equal(textarea.value, 'WO');
 	insert(textarea, 'A');
@@ -71,7 +71,7 @@ test('replace selected text', t => {
 	t.end();
 });
 
-test('fire input event', t => {
+test('insert() fires input event', t => {
 	const textarea = getField();
 	textarea.addEventListener('input', event => {
 		t.equal(event.type, 'input');
@@ -79,4 +79,54 @@ test('fire input event', t => {
 		t.end();
 	});
 	insert(textarea, 'A');
+});
+
+test('set() replaces the whole content', t => {
+	const textarea = getField('WO', 0, 1);
+	t.equal(textarea.value, 'WO');
+	set(textarea, 'ABC');
+	t.equal(textarea.value, 'ABC');
+	t.equal(textarea.selectionStart, 3);
+	t.equal(textarea.selectionEnd, 3);
+	t.end();
+});
+
+test('getSelection()', t => {
+	const textarea = getField('WOA', 1, 2);
+	t.equal(textarea.value, 'WOA');
+	t.equal(getSelection(textarea), 'O');
+	t.end();
+});
+
+test('getSelection() without selection', t => {
+	const textarea = getField('WOA', 3, 3);
+	t.equal(getSelection(textarea), '');
+	t.end();
+});
+
+test('wrapSelection() wraps selected text', t => {
+	const textarea = getField('WOA', 1, 2);
+	wrapSelection(textarea, '*');
+	t.equal(textarea.value, 'W*O*A');
+	t.equal(textarea.selectionStart, 2);
+	t.equal(textarea.selectionEnd, 3);
+	t.end();
+});
+
+test('wrapSelection() wraps selected text with different characters', t => {
+	const textarea = getField('WOA', 1, 2);
+	wrapSelection(textarea, '[', ']');
+	t.equal(textarea.value, 'W[O]A');
+	t.equal(textarea.selectionStart, 2);
+	t.equal(textarea.selectionEnd, 3);
+	t.end();
+});
+
+test('wrapSelection() adds wrapping characters even without selection', t => {
+	const textarea = getField('OA', 1, 1);
+	wrapSelection(textarea, '[', ']');
+	t.equal(textarea.value, 'O[]A');
+	t.equal(textarea.selectionStart, 2);
+	t.equal(textarea.selectionEnd, 2);
+	t.end();
 });


### PR DESCRIPTION
Changes from

```js
import insertTextArea from 'insert-text-area';

insertTextArea(field, 'add text');
```

to

```js
import textFieldEdit from 'text-field-edit';

textFieldEdit.insert(field, 'add text');
textFieldEdit.set(field, 'new text');
textFieldEdit.wrapSelection(field, '[', ']');
textFieldEdit.getSelection(field);
```

- [ ] TODO: fix tsc/xo usage in ci