### PR TITLE
Workaround for Firefox `insert(emptyString)` bug

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,12 @@
+// https://github.com/fregante/text-field-edit/issues/16
+function safeTextInsert(text: string): boolean {
+	if (text === '') {
+		return document.execCommand('delete');
+	}
+
+	return document.execCommand('insertText', false, text);
+}
+
 function insertTextFirefox(
 	field: HTMLTextAreaElement | HTMLInputElement,
 	text: string,
@@ -29,7 +38,7 @@ export function insert(
 		field.focus();
 	}
 
-	if (!document.execCommand('insertText', false, text)) {
+	if (!safeTextInsert(text)) {
 		insertTextFirefox(field, text);
 	}
 

--- a/test.js
+++ b/test.js
@@ -80,6 +80,13 @@ test('insert() replaces selected text', t => {
 	t.end();
 });
 
+test('insert() replaces selected text even if string is ""', t => {
+	const field = getField('{W}O');
+	textFieldEdit.insert(field, '');
+	t.equal(getState(field), '|O');
+	t.end();
+});
+
 test('insert() fires input event', t => {
 	const field = getField();
 	field.addEventListener('input', event => {


### PR DESCRIPTION
- Fixes #16