### PR TITLE
In .replace(), optionally avoid selecting the text after the replacement

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -87,6 +87,7 @@ export function replace(
 	field: HTMLTextAreaElement | HTMLInputElement,
 	searchValue: string | RegExp,
 	replacer: string | ReplacerCallback,
+	cursor: 'select' | 'after-replacement' = 'select',
 ): void {
 	/** Remembers how much each match offset should be adjusted */
 	let drift = 0;
@@ -101,8 +102,11 @@ export function replace(
 		const replacement = typeof replacer === 'string' ? replacer : replacer(...args);
 		insert(field, replacement);
 
-		// Select replacement. Without this, the cursor would be after the replacement
-		field.selectionStart = matchStart;
+		if (cursor === 'select') {
+			// Select replacement. Without this, the cursor would be after the replacement
+			field.selectionStart = matchStart;
+		}
+
 		drift += replacement.length - matchLength;
 		return replacement;
 	});

--- a/test.js
+++ b/test.js
@@ -146,6 +146,15 @@ test('replace() supports strings', t => {
 	t.end();
 });
 
+test('replace() supports strings with cursor placed after replaced text', t => {
+	const field = getField('ABACUS');
+	textFieldEdit.replace(field, 'A', 'THE ', 'after-replacement');
+	t.equal(getState(field), 'THE |BACUS');
+	textFieldEdit.replace(field, 'BA', 'AR', 'after-replacement');
+	t.equal(getState(field), 'THE AR|CUS');
+	t.end();
+});
+
 test('replace() supports strings with a replacer function', t => {
 	const field = getField('ABACUS');
 	textFieldEdit.replace(field, 'A', (match, index, string) => {


### PR DESCRIPTION
I am not sure if it fixed #14, but it does resolve our use case.