### PR TITLE
Add default export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -111,3 +111,6 @@ export function replace(
 		return replacement;
 	});
 }
+
+const textFieldEdit = {insert, set, replace, wrapSelection};
+export default textFieldEdit;


### PR DESCRIPTION
While not the best option, this makes it easy to autocomplete the imports.

I'll also likely rename the methods to `setFieldValue`, etc instead of just `set`