### PR TITLE
Drop Firefox 89- fallback

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,8 +13,8 @@ export function insert(
 		// https://github.com/fregante/text-field-edit/issues/16
 		document.execCommand('delete');
 	} else {
-                document.execCommand('insertText', false, text);
-        }
+		document.execCommand('insertText', false, text);
+	}
 
 	if (initialFocus === document.body) {
 		field.blur();

--- a/index.ts
+++ b/index.ts
@@ -12,9 +12,9 @@ export function insert(
 	if (text === '') {
 		// https://github.com/fregante/text-field-edit/issues/16
 		document.execCommand('delete');
-	}
-
-	document.execCommand('insertText', false, text);
+	} else {
+                document.execCommand('insertText', false, text);
+        }
 
 	if (initialFocus === document.body) {
 		field.blur();

--- a/index.ts
+++ b/index.ts
@@ -1,32 +1,3 @@
-// https://github.com/fregante/text-field-edit/issues/16
-function safeTextInsert(text: string): boolean {
-	if (text === '') {
-		return document.execCommand('delete');
-	}
-
-	return document.execCommand('insertText', false, text);
-}
-
-function insertTextFirefox(
-	field: HTMLTextAreaElement | HTMLInputElement,
-	text: string,
-): void {
-	// Found on https://www.everythingfrontend.com/posts/insert-text-into-textarea-at-cursor-position.html 🎈
-	field.setRangeText(
-		text,
-		field.selectionStart || 0,
-		field.selectionEnd || 0,
-		'end', // Without this, the cursor is either at the beginning or `text` remains selected
-	);
-
-	field.dispatchEvent(
-		new InputEvent('input', {
-			data: text,
-			inputType: 'insertText',
-		}),
-	);
-}
-
 /** Inserts `text` at the cursor’s position, replacing any selection, with **undo** support and by firing the `input` event. */
 export function insert(
 	field: HTMLTextAreaElement | HTMLInputElement,
@@ -38,9 +9,12 @@ export function insert(
 		field.focus();
 	}
 
-	if (!safeTextInsert(text)) {
-		insertTextFirefox(field, text);
+	if (text === '') {
+		// https://github.com/fregante/text-field-edit/issues/16
+		document.execCommand('delete');
 	}
+
+	document.execCommand('insertText', false, text);
 
 	if (initialFocus === document.body) {
 		field.blur();


### PR DESCRIPTION
It's been two years since Firefox has supported `execCommand`, so it's time to drop it.