### PR TITLE
Add default export; rename named exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,21 @@ jobs:
   Types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - run: npm ci
       - run: tsc
 
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - run: npm ci
       - run: npx xo
 
   Firefox:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - run: npm ci
       - run: tsc
       - run: xvfb-run npm run test:gecko
@@ -30,7 +30,7 @@ jobs:
   Chrome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - run: npm ci
       - run: tsc
       - run: xvfb-run npm run test:blink

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,21 @@ jobs:
   Types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: tsc
 
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: npx xo
 
   Firefox:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: tsc
       - run: xvfb-run npm run test:gecko
@@ -30,7 +30,7 @@ jobs:
   Chrome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: tsc
       - run: xvfb-run npm run test:blink

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 /** Inserts `text` at the cursor’s position, replacing any selection, with **undo** support and by firing the `input` event. */
-export function insertTextInField(
+export function insertTextIntoField(
 	field: HTMLTextAreaElement | HTMLInputElement,
 	text: string,
 ): void {
@@ -29,7 +29,7 @@ export function setFieldText(
 	text: string,
 ): void {
 	field.select();
-	insertTextInField(field, text);
+	insertTextIntoField(field, text);
 }
 
 /** Get the selected text in a field or an empty string if nothing is selected. */
@@ -47,7 +47,7 @@ export function wrapSelectionInField(
 ): void {
 	const {selectionStart, selectionEnd} = field;
 	const selection = getFieldSelection(field);
-	insertTextInField(field, wrap + selection + (wrapEnd ?? wrap));
+	insertTextIntoField(field, wrap + selection + (wrapEnd ?? wrap));
 
 	// Restore the selection around the previously-selected text
 	field.selectionStart = selectionStart! + wrap.length;
@@ -74,7 +74,7 @@ export function replaceFieldText(
 		field.selectionEnd = matchStart + matchLength;
 
 		const replacement = typeof replacer === 'string' ? replacer : replacer(...args);
-		insertTextInField(field, replacement);
+		insertTextIntoField(field, replacement);
 
 		if (cursor === 'select') {
 			// Select replacement. Without this, the cursor would be after the replacement
@@ -86,8 +86,8 @@ export function replaceFieldText(
 	});
 }
 
-/** @deprecated Import `insertTextInField` instead */
-export const insert = insertTextInField;
+/** @deprecated Import `insertTextIntoField` instead */
+export const insert = insertTextIntoField;
 
 /** @deprecated Import `setFieldText` instead */
 export const set = setFieldText;
@@ -100,7 +100,7 @@ export const wrap = wrapSelectionInField;
 
 // Note: Don't reuse deprecated constant from above
 const textFieldEdit = {
-	insert: insertTextInField,
+	insert: insertTextIntoField,
 	set: setFieldText,
 	replace: replaceFieldText,
 	wrap: wrapSelectionInField,

--- a/index.ts
+++ b/index.ts
@@ -40,7 +40,7 @@ export function getFieldSelection(
 }
 
 /** Adds the `wrappingText` before and after field’s selection (or cursor). If `endWrappingText` is provided, it will be used instead of `wrappingText` at on the right. */
-export function wrapSelectionInField(
+export function wrapFieldSelection(
 	field: HTMLTextAreaElement | HTMLInputElement,
 	wrap: string,
 	wrapEnd?: string,
@@ -95,14 +95,18 @@ export const set = setFieldText;
 /** @deprecated Import `replaceFieldText` instead */
 export const replace = replaceFieldText;
 
-/** @deprecated Import `wrapSelectionInField` instead */
-export const wrap = wrapSelectionInField;
+/** @deprecated Import `wrapFieldSelection` instead */
+export const wrapSelection = wrapFieldSelection;
+
+/** @deprecated Import `getFieldSelection` instead */
+export const getSelection = getFieldSelection;
 
 // Note: Don't reuse deprecated constant from above
 const textFieldEdit = {
 	insert: insertTextIntoField,
 	set: setFieldText,
 	replace: replaceFieldText,
-	wrap: wrapSelectionInField,
+	wrapSelection: wrapFieldSelection,
+	getSelection: getFieldSelection,
 } as const;
 export default textFieldEdit;

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 /** Inserts `text` at the cursor’s position, replacing any selection, with **undo** support and by firing the `input` event. */
-export function insert(
+export function insertTextInField(
 	field: HTMLTextAreaElement | HTMLInputElement,
 	text: string,
 ): void {
@@ -24,30 +24,30 @@ export function insert(
 }
 
 /** Replaces the entire content, equivalent to `field.value = text` but with **undo** support and by firing the `input` event. */
-export function set(
+export function setFieldText(
 	field: HTMLTextAreaElement | HTMLInputElement,
 	text: string,
 ): void {
 	field.select();
-	insert(field, text);
+	insertTextInField(field, text);
 }
 
 /** Get the selected text in a field or an empty string if nothing is selected. */
-export function getSelection(
+export function getFieldSelection(
 	field: HTMLTextAreaElement | HTMLInputElement,
 ): string {
 	return field.value.slice(field.selectionStart!, field.selectionEnd!);
 }
 
 /** Adds the `wrappingText` before and after field’s selection (or cursor). If `endWrappingText` is provided, it will be used instead of `wrappingText` at on the right. */
-export function wrapSelection(
+export function wrapSelectionInField(
 	field: HTMLTextAreaElement | HTMLInputElement,
 	wrap: string,
 	wrapEnd?: string,
 ): void {
 	const {selectionStart, selectionEnd} = field;
-	const selection = getSelection(field);
-	insert(field, wrap + selection + (wrapEnd ?? wrap));
+	const selection = getFieldSelection(field);
+	insertTextInField(field, wrap + selection + (wrapEnd ?? wrap));
 
 	// Restore the selection around the previously-selected text
 	field.selectionStart = selectionStart! + wrap.length;
@@ -57,7 +57,7 @@ export function wrapSelection(
 type ReplacerCallback = (substring: string, ...args: any[]) => string;
 
 /** Finds and replaces strings and regex in the field’s value, like `field.value = field.value.replace()` but better */
-export function replace(
+export function replaceFieldText(
 	field: HTMLTextAreaElement | HTMLInputElement,
 	searchValue: string | RegExp,
 	replacer: string | ReplacerCallback,
@@ -74,7 +74,7 @@ export function replace(
 		field.selectionEnd = matchStart + matchLength;
 
 		const replacement = typeof replacer === 'string' ? replacer : replacer(...args);
-		insert(field, replacement);
+		insertTextInField(field, replacement);
 
 		if (cursor === 'select') {
 			// Select replacement. Without this, the cursor would be after the replacement
@@ -86,5 +86,23 @@ export function replace(
 	});
 }
 
-const textFieldEdit = {insert, set, replace, wrapSelection};
+/** @deprecated Import `insertTextInField` instead */
+export const insert = insertTextInField;
+
+/** @deprecated Import `setFieldText` instead */
+export const set = setFieldText;
+
+/** @deprecated Import `replaceFieldText` instead */
+export const replace = replaceFieldText;
+
+/** @deprecated Import `wrapSelectionInField` instead */
+export const wrap = wrapSelectionInField;
+
+// Note: Don't reuse deprecated constant from above
+const textFieldEdit = {
+	insert: insertTextInField,
+	set: setFieldText,
+	replace: replaceFieldText,
+	wrap: wrapSelectionInField,
+} as const;
 export default textFieldEdit;

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ import {
 	insertTextIntoField,
 	setFieldText,
 	getFieldSelection,
-	wrapSelectionInField,
+	wrapFieldSelection,
 	replaceFieldText,
 } from 'text-field-edit';
 ```

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ import textFieldEdit from 'text-field-edit';
 
 // Alternatively only import the specific methods
 import {
-	insertTextInField,
+	insertTextIntoField,
 	setFieldText,
 	getFieldSelection,
 	wrapSelectionInField,

--- a/readme.md
+++ b/readme.md
@@ -27,8 +27,16 @@ npm install text-field-edit
 ```
 
 ```js
-// This module is only offered as a ES Module
-import * as textFieldEdit from 'text-field-edit';
+import textFieldEdit from 'text-field-edit';
+
+// Alternatively only import the specific methods
+import {
+	insertTextInField,
+	setFieldText,
+	getFieldSelection,
+	wrapSelectionInField,
+	replaceFieldText,
+} from 'text-field-edit';
 ```
 
 ## Usage
@@ -160,4 +168,4 @@ Type: `HTMLTextAreaElement | HTMLInputElement`
 
 - [indent-textarea](https://github.com/fregante/indent-textarea) - Add editor-like tab-to-indent functionality to `<textarea>`, in a few bytes. Uses this module.
 - [fit-textarea](https://github.com/fregante/fit-textarea) - Automatically expand a `<textarea>` to fit its content, in a few bytes.
-- [Refined GitHub](https://github.com/sindresorhus/refined-github) - Uses this module.
+- [Refined GitHub](https://github.com/refined-github/refined-github) - Uses this module.

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'tape';
-import * as textFieldEdit from '.';
+import textFieldEdit from '.';
 
 function getField(state = '|', type = 'textarea') {
 	const field = document.createElement(type);


### PR DESCRIPTION
Existing imports will continue working without change, but they've been deprecated, so eventually they need to be updated to:

```diff
- import * as textFieldEdit from 'text-field-edit';
+ import textFieldEdit from 'text-field-edit';
```


```diff
- import {insert} from 'text-field-edit';
+ import {insertTextIntoField} from 'text-field-edit';
```




